### PR TITLE
Database chores

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 
 # Used by Prisma to connect to the database
-DATABASE_URL="postgresql://api:api@db:5432/paastech"
+DATABASE_URL="postgresql://api:api@127.0.0.1:5432/paastech"

--- a/README.md
+++ b/README.md
@@ -10,17 +10,33 @@ PaaSTech API's [Nest](https://github.com/nestjs/nest) framework TypeScript repos
 $ npm install
 ```
 
-## Running the app
+## Development
 
-```bash
-# development
-$ npm run start
+First, copy `.env.example` into your own `.env` file and replace all appropriate values.
 
-# watch mode
-$ npm run start:dev
+**WARNING**: There should be *no need* to replace the given default `DATABASE_URL`,
+which is already fully configured to use in development mode.
 
-# production mode
-$ npm run start:prod
+To run the application, you will need to use the Docker Compose in the root folder:
+
+```sh
+$ docker compose up -d
+```
+
+After this, you will need to run **once**:
+
+```sh
+# generates prisma's client for TS types and classes
+$ npx prisma generate
+
+# applies the migrations to the database
+$ npx prisma migrate deploy
+```
+
+If you need to generate migrations after editing the `schema.prisma` file, you can run:
+
+```sh
+$ npx prisma migrate dev --name "name of your migration here"
 ```
 
 ## Test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
     container_name: paastech-api-db
     networks:
       - internal
+    ports:
+      - 5432:5432
     volumes:
       - ./.db_data:/var/lib/postgresql/data:rw
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,10 +16,10 @@ services:
     container_name: paastech-api-node
     working_dir: /opt
     command: npm run start
-    networks:
-      - internal
-    ports:
-      - 80:3000
+    # network is in host mode for dev interoperability
+    # this allows for ORM commands to be run from the host machine
+    # as the env variables do not need to change from the host to the container
+    network_mode: host
     volumes:
       # read-write is necessary for build and use
       - ./:/opt:rw
@@ -33,11 +33,12 @@ services:
     networks:
       - internal
     ports:
+      # publishing the port for the other container to reach
       - 5432:5432
     volumes:
       - ./.db_data:/var/lib/postgresql/data:rw
     healthcheck:
-      test: /usr/local/bin/pg_isready -U api
+      test: /usr/local/bin/pg_isready -U api -d paastech
       interval: 5s
       timeout: 10s
       retries: 4

--- a/prisma/migrations/20230626170935_nullable_updated_at/migration.sql
+++ b/prisma/migrations/20230626170935_nullable_updated_at/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "deployments" ALTER COLUMN "updated_at" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "projects" ALTER COLUMN "updated_at" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "ssh_keys" ALTER COLUMN "updated_at" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "users" ALTER COLUMN "updated_at" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,7 +19,7 @@ model User {
   isAdmin     Boolean   @map("is_admin")
   email_nonce String?   @db.VarChar(255)
   createdAt   DateTime  @default(now()) @map("created_at")
-  updatedAt   DateTime  @updatedAt @map("updated_at")
+  updatedAt   DateTime? @updatedAt @map("updated_at")
   projects    Project[]
   ssh_keys    SshKey[]
 
@@ -27,12 +27,12 @@ model User {
 }
 
 model SshKey {
-  id        Int      @id @default(autoincrement())
+  id        Int       @id @default(autoincrement())
   value     String
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
-  user      User     @relation(fields: [userId], references: [id])
-  userId    Int      @unique @map("user_id")
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime? @updatedAt @map("updated_at")
+  user      User      @relation(fields: [userId], references: [id])
+  userId    Int       @unique @map("user_id")
 
   @@map("ssh_keys")
 }
@@ -42,7 +42,7 @@ model Project {
   uuid        String       @unique @db.Uuid
   name        String       @db.VarChar(40)
   createdAt   DateTime     @default(now()) @map("created_at")
-  updatedAt   DateTime     @updatedAt @map("updated_at")
+  updatedAt   DateTime?    @updatedAt @map("updated_at")
   user        User         @relation(fields: [userId], references: [id])
   userId      Int          @unique @map("user_id")
   deployments Deployment[]
@@ -55,10 +55,10 @@ model Deployment {
   uuid      String   @unique @db.Uuid
   name      String   @db.VarChar(40)
   config    Json
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
-  project   Project  @relation(fields: [projectId], references: [id])
-  projectId Int      @unique @map("project_id")
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime? @updatedAt @map("updated_at")
+  project   Project   @relation(fields: [projectId], references: [id])
+  projectId Int       @unique @map("project_id")
 
   @@map("deployments")
 }


### PR DESCRIPTION
A few chores have been done:

- add documentation for how to use the Docker Compose file, how to generate the Prisma Client and how to deploy migrations;
- the Docker Compose file has been improved so we can use the Prisma CLI from the host machine and not from the container anymore;
- a new migration has been generated to allow systems that don't support `updatedAt` fields to interact with the database, or at least have the same structure as us.