### PR TITLE
OpenAPI spec and Swagger UI

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -5,6 +5,7 @@
   "compilerOptions": {
     "deleteOutDir": true,
     "assets": ["mail/templates/**/*.hbs"],
+    "plugins": ["@nestjs/swagger"],
     "watchAssets": true
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/jwt": "^10.1.0",
         "@nestjs/passport": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/swagger": "^7.1.1",
         "@prisma/client": "^4.16.1",
         "bcrypt": "^5.1.0",
         "class-validator": "^0.14.0",
@@ -1595,6 +1596,25 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.2.tgz",
+      "integrity": "sha512-V0izw6tWs6fTp9+KiiPUbGHWALy563Frn8X6Bm87ANLRuE46iuBMD5acKBDP5lKL/75QFvrzSJT7HkCbB0jTpg==",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/passport": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-10.0.0.tgz",
@@ -1638,6 +1658,37 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.2"
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.1.1.tgz",
+      "integrity": "sha512-gIG1aVCegZlIppXZizKHqWkqZvQkvptTBR1C5CzZoDwGoVVKJBmJ2i9FAcsnzzb0j7hncFKhcBuWYOBJOsCvug==",
+      "dependencies": {
+        "@nestjs/mapped-types": "2.0.2",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0",
+        "swagger-ui-dist": "5.1.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {
@@ -2904,8 +2955,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -6443,7 +6493,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -8539,6 +8588,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.1.0.tgz",
+      "integrity": "sha512-c1KmAjuVODxw+vwkNLALQZrgdlBAuBbr2xSPfYrJgseEi7gFKcTvShysPmyuDI4kcUa1+5rFpjWvXdusKY74mg=="
     },
     "node_modules/symbol-observable": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@nestjs/jwt": "^10.1.0",
     "@nestjs/passport": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^7.1.1",
     "@prisma/client": "^4.16.1",
     "bcrypt": "^5.1.0",
     "class-validator": "^0.14.0",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -6,7 +6,9 @@ import { Public } from './decorators/public.decorator';
 import { CreateUserDto } from 'src/users/dto/create-user.dto';
 import { UsersService } from 'src/users/users.service';
 import { SanitizedUser } from 'src/users/types/sanitized-user.type';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('auth')
 @Controller('auth')
 export class AuthController {
     constructor(

--- a/src/auth/interfaces/accessToken.ts
+++ b/src/auth/interfaces/accessToken.ts
@@ -1,3 +1,6 @@
-export interface AccessToken {
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AccessToken {
+    @ApiProperty()
     accessToken: string;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { ValidationPipe } from '@nestjs/common';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
@@ -7,6 +8,19 @@ async function bootstrap() {
   app.useGlobalPipes(new ValidationPipe({
     whitelist: true,
   }));
+
+  const config = new DocumentBuilder()
+    .setTitle('PaaSTech API')
+    .setDescription('Client API for the PaaSTech project')
+    .setVersion('1.0')
+    .addTag('auth')
+    .addTag('users')
+    .addTag('projects')
+    .addBearerAuth()
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
+
   await app.listen(3000);
 }
 bootstrap();

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -3,7 +3,10 @@ import { AdminOnly } from 'src/auth/decorators/adminonly.decorator';
 import { CreateProjectDto } from './dto/create-project.dto';
 import { ProjectsService } from './projects.service';
 import { SanitizedProject } from './types/sanitized-project.type';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
+@ApiBearerAuth()
+@ApiTags('projects')
 @Controller('projects')
 export class ProjectsController {
     constructor(private projectsService: ProjectsService) {}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -3,7 +3,10 @@ import { Body, Controller, Delete, Get, HttpException, HttpStatus, Param, Patch,
 import { SetSshDto } from './dto/set-ssh.dto';
 import { UsersService } from './users.service';
 import { AdminOnly } from 'src/auth/decorators/adminonly.decorator';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
+@ApiBearerAuth()
+@ApiTags('users')
 @Controller('users')
 export class UsersController {
     constructor(


### PR DESCRIPTION
### What does this PR do ?
Initializes Swagger using the SwaggerModule, allows using Swagger UI for testing and autogenerates OpenAPI spec.

### How to test
- run `npm i`
- delete *dist* folder
- run `npm run start:dev`

### TODO
See if we can figure out a way to make the OpenAPI spec more precise regarding the endpoints return types and codes.