### PR TITLE
refactor: database change for ssh keys

### DIFF
--- a/prisma/migrations/20230707141849_init/migration.sql
+++ b/prisma/migrations/20230707141849_init/migration.sql
@@ -15,7 +15,7 @@ CREATE TABLE "users" (
 
 -- CreateTable
 CREATE TABLE "ssh_keys" (
-    "id" SERIAL NOT NULL,
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
     "value" TEXT NOT NULL,
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3),

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,7 +28,7 @@ model User {
 }
 
 model SshKey {
-  id        Int       @id @default(autoincrement())
+  id        String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   value     String
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime? @updatedAt @map("updated_at")


### PR DESCRIPTION
Change the database id for ssh keys into a UUID, for safe sharing to the public and easier management.

BREAKING CHANGE