### PR TITLE
hotfix(scripts): wrong file location in start:prod for main.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/src/main",
     "start:migrate:prod": "prisma migrate deploy && npm run start:prod",
     "lint": "eslint \"{prisma,src,test}/**/*.{js,ts}\" && npx prettier \"{prisma,src,test}/**/*.{js,ts}\" -c",
     "fmt": "eslint \"{prisma,src,test}/**/*.{js,ts}\" --fix && npx prettier \"{prisma,src,test}/**/*.{js,ts}\" -wc",


### PR DESCRIPTION
Cannot start the prod server, because the main.js file is not in `dist/` but in `dist/src`