### PR TITLE
Add Swagger response decorator to every endpoint

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -21,7 +21,7 @@ export class AuthController {
   // POST /auth/login
   // This action returns an access token
   @Public()
-  @ApiResponse({ status: 201, type: ApiStandardResponse })
+  @ApiCreatedResponse({ type: ApiStandardResponse })
   @Post('login')
   async login(@Response({ passthrough: true }) response: EResponse, @Body() loginUserDto: LoginUserDto): Promise<CompliantContentResponse<AccessToken>> {
     return this.authService.login(response, loginUserDto);
@@ -48,7 +48,7 @@ export class AuthController {
   // POST /auth/confirm/:token
   // This path lets the user confirm his email
   @Public()
-  @ApiResponse({ status: 201, type: ApiStandardResponse })
+  @ApiCreatedResponse({ type: ApiStandardResponse })
   @Post('confirm/:token')
   async confirmEmail(@Param('token', new ParseUUIDPipe()) token: string): Promise<MessageResponse> {
     if (!(await this.authService.confirmEmail(token))) {
@@ -60,7 +60,7 @@ export class AuthController {
   // POST /auth/password/request
   // This path lets the user request to change his password
   @Public()
-  @ApiResponse({ status: 201, type: ApiStandardResponse })
+  @ApiCreatedResponse({ type: ApiStandardResponse })
   @Post('password/request')
   async requestPassword(@Body() passwordRequestDto: PasswordRequestDto): Promise<MessageResponse> {
     await this.authService.passwordRequest(passwordRequestDto);
@@ -71,7 +71,7 @@ export class AuthController {
   // POST /auth/password/reset
   // This path lets the user reset his password
   @Public()
-  @ApiResponse({ status: 201, type: ApiStandardResponse })
+  @ApiCreatedResponse({ type: ApiStandardResponse })
   @Post('password/reset/:token')
   async resetPassword(@Param('token', new ParseUUIDPipe()) token: string, @Body() passwordResetDto: PasswordResetDto): Promise<MessageResponse> {
     if (!(await this.authService.passwordReset(token, passwordResetDto))) {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -5,7 +5,7 @@ import { AccessToken } from './dto/responses/access-token.dto';
 import { Public } from '../decorators/public.decorator';
 import { CreateUserDto } from 'src/users/dto/create-user.dto';
 import { SanitizedUser } from 'src/users/types/sanitized-user.type';
-import { ApiBearerAuth, ApiCookieAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiCookieAuth, ApiCreatedResponse, ApiOkResponse, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { PasswordRequestDto } from './dto/password-request.dto';
 import { PasswordResetDto } from './dto/password-reset.dto';
 import { Response as EResponse } from 'express';
@@ -21,11 +21,13 @@ export class AuthController {
   // POST /auth/login
   // This action returns an access token
   @Public()
+  @ApiResponse({ status: 201, type: ApiStandardResponse })
   @Post('login')
   async login(@Response({ passthrough: true }) response: EResponse, @Body() loginUserDto: LoginUserDto): Promise<CompliantContentResponse<AccessToken>> {
     return this.authService.login(response, loginUserDto);
   }
 
+  @ApiOkResponse({ type: ApiStandardResponse })
   @Post('logout')
   @HttpCode(200)
   @ApiBearerAuth()
@@ -37,6 +39,7 @@ export class AuthController {
   // POST /auth/register
   // This action adds a new user
   @Public()
+  @ApiCreatedResponse({ type: ApiStandardResponse })
   @Post('register')
   async register(@Body() createUserDto: CreateUserDto): Promise<CompliantContentResponse<SanitizedUser>> {
     return await this.authService.register(createUserDto);
@@ -45,6 +48,7 @@ export class AuthController {
   // POST /auth/confirm/:token
   // This path lets the user confirm his email
   @Public()
+  @ApiResponse({ status: 201, type: ApiStandardResponse })
   @Post('confirm/:token')
   async confirmEmail(@Param('token', new ParseUUIDPipe()) token: string): Promise<MessageResponse> {
     if (!(await this.authService.confirmEmail(token))) {
@@ -56,6 +60,7 @@ export class AuthController {
   // POST /auth/password/request
   // This path lets the user request to change his password
   @Public()
+  @ApiResponse({ status: 201, type: ApiStandardResponse })
   @Post('password/request')
   async requestPassword(@Body() passwordRequestDto: PasswordRequestDto): Promise<MessageResponse> {
     await this.authService.passwordRequest(passwordRequestDto);
@@ -66,6 +71,7 @@ export class AuthController {
   // POST /auth/password/reset
   // This path lets the user reset his password
   @Public()
+  @ApiResponse({ status: 201, type: ApiStandardResponse })
   @Post('password/reset/:token')
   async resetPassword(@Param('token', new ParseUUIDPipe()) token: string, @Body() passwordResetDto: PasswordResetDto): Promise<MessageResponse> {
     if (!(await this.authService.passwordReset(token, passwordResetDto))) {

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -6,7 +6,7 @@ import { GetUser } from 'src/decorators/user.decorator';
 import { RequestUser } from 'src/auth/types/jwt-user-data.type';
 import { GetStatusDto } from './dto/get-status.dto';
 import { DeployDto } from './dto/deploy.dto';
-import { ApiBearerAuth, ApiCookieAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiCookieAuth, ApiCreatedResponse, ApiOkResponse, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ApiStandardResponse } from 'src/interfaces/standard-response.inteface';
 import { CompliantContentResponse } from 'src/types/standard-response.type';
 
@@ -20,6 +20,7 @@ export class ProjectsController {
 
   // GET /projects
   // This action returns all of the authenticated user's projects
+  @ApiOkResponse({ type: ApiStandardResponse })
   @Get()
   async findAll(@GetUser() user: RequestUser): Promise<CompliantContentResponse<SanitizedProject[]>> {
     return this.projectsService.findAll(user.id);
@@ -27,6 +28,7 @@ export class ProjectsController {
 
   // GET /projects/:uuid
   // This action returns a #${id} project;
+  @ApiOkResponse({ type: ApiStandardResponse })
   @Get(':uuid')
   async findOne(@Param('uuid', new ParseUUIDPipe()) id: string, @GetUser() user: RequestUser): Promise<CompliantContentResponse<SanitizedProject>> {
     return this.projectsService.findOne(id, user.id);
@@ -38,6 +40,7 @@ export class ProjectsController {
         and returns a NewProject Object
         with the project's id and name
     */
+  @ApiCreatedResponse({ type: ApiStandardResponse })
   @Post()
   async create(@Body() request: CreateProjectDto, @GetUser() user: RequestUser): Promise<CompliantContentResponse<SanitizedProject>> {
     return await this.projectsService.create(user.id, request.name);
@@ -45,6 +48,7 @@ export class ProjectsController {
 
   // DELETE /projects/:uuid
   // This action deletes a #${id} project
+  @ApiOkResponse({ type: ApiStandardResponse })
   @Delete(':uuid')
   async delete(@Param('uuid', new ParseUUIDPipe()) uuid: string, @GetUser() user: RequestUser): Promise<CompliantContentResponse<SanitizedProject>> {
     return await this.projectsService.delete(uuid, user.id);
@@ -52,6 +56,7 @@ export class ProjectsController {
 
   // Patch /projects/:uuid/start
   // This starts a deployment for a project
+  @ApiOkResponse({ type: ApiStandardResponse })
   @Patch(':uuid/deploy')
   async deploy(@Param('uuid') uuid: string, @GetUser() user: RequestUser, @Body() request: DeployDto): Promise<CompliantContentResponse<SanitizedProject>> {
     return this.projectsService.deploy(uuid, user.id, request.env_vars);
@@ -59,6 +64,7 @@ export class ProjectsController {
 
   // POST /projects/:uuid/stop
   // This stops a deployment for a project
+  @ApiResponse({ status: 201, type: ApiStandardResponse })
   @Post(':uuid/stop')
   async stop(@Param('uuid') uuid: string, @GetUser() user: RequestUser): Promise<CompliantContentResponse<SanitizedProject>> {
     return this.projectsService.stopDeployment(uuid, user.id);
@@ -66,6 +72,7 @@ export class ProjectsController {
 
   // GET /projects/:uuid/logs
   // This gets logs for a deployment
+  @ApiOkResponse({ type: ApiStandardResponse })
   @Get(':uuid/logs')
   async getLogs(@Param('uuid') uuid: string, @GetUser() user: RequestUser): Promise<CompliantContentResponse<SanitizedProject>> {
     return this.projectsService.getDeploymentLogs(uuid, user.id);
@@ -73,6 +80,7 @@ export class ProjectsController {
 
   // GET /projects/:uuid/statistics
   // This gets statistics for a deployment
+  @ApiOkResponse({ type: ApiStandardResponse })
   @Get(':uuid/statistics')
   async getStatistics(@Param('uuid') uuid: string, @GetUser() user: RequestUser): Promise<CompliantContentResponse<SanitizedProject>> {
     return await this.projectsService.getStatistics(uuid, user.id);
@@ -80,6 +88,7 @@ export class ProjectsController {
 
   // POST /projects/status
   // This gets status for one or more deployments
+  @ApiResponse({ status: 201, type: ApiStandardResponse })
   @Post('/status')
   async getStatus(@Body() request: GetStatusDto, @GetUser() user: RequestUser): Promise<CompliantContentResponse<SanitizedProject>> {
     return await this.projectsService.getStatus(request.container_names, user.id);

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -64,7 +64,7 @@ export class ProjectsController {
 
   // POST /projects/:uuid/stop
   // This stops a deployment for a project
-  @ApiResponse({ status: 201, type: ApiStandardResponse })
+  @ApiCreatedResponse({ type: ApiStandardResponse })
   @Post(':uuid/stop')
   async stop(@Param('uuid') uuid: string, @GetUser() user: RequestUser): Promise<CompliantContentResponse<SanitizedProject>> {
     return this.projectsService.stopDeployment(uuid, user.id);
@@ -88,7 +88,7 @@ export class ProjectsController {
 
   // POST /projects/status
   // This gets status for one or more deployments
-  @ApiResponse({ status: 201, type: ApiStandardResponse })
+  @ApiCreatedResponse({ type: ApiStandardResponse })
   @Post('/status')
   async getStatus(@Body() request: GetStatusDto, @GetUser() user: RequestUser): Promise<CompliantContentResponse<SanitizedProject>> {
     return await this.projectsService.getStatus(request.container_names, user.id);

--- a/src/sshkeys/sshkeys.controller.ts
+++ b/src/sshkeys/sshkeys.controller.ts
@@ -4,7 +4,7 @@ import { AdminOnly } from 'src/decorators/adminonly.decorator';
 import { CreateSshKeyDto } from './dto/create-sshkey.dto';
 import { GetUser } from 'src/decorators/user.decorator';
 import { RequestUser } from 'src/auth/types/jwt-user-data.type';
-import { ApiBearerAuth, ApiCookieAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiCookieAuth, ApiCreatedResponse, ApiOkResponse, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ApiStandardResponse } from 'src/interfaces/standard-response.inteface';
 import { CompliantContentResponse, MessageResponse } from 'src/types/standard-response.type';
 import { SanitizedSshKey } from './types/sanitized-ssh-key';
@@ -19,6 +19,7 @@ export class SshKeysController {
 
   // POST /sshkeys/my
   // This action adds a key ${setSshDto} to a user's keys
+  @ApiCreatedResponse({ type: ApiStandardResponse })
   @Post('my')
   async createSshKey(@Body() createSshDto: CreateSshKeyDto, @GetUser() user: RequestUser): Promise<MessageResponse> {
     if (!(await this.sshkeysService.createSshKey(user.id, createSshDto))) {
@@ -32,6 +33,7 @@ export class SshKeysController {
 
   // DELETE /sshkeys/:username
   // This action removes a key ${setSshDto} to a user's keys
+  @ApiOkResponse({ type: ApiStandardResponse })
   @Delete('my/:uuid')
   async deleteSshKey(@Param('uuid', new ParseUUIDPipe()) uuidSshKey: string, @GetUser() user: RequestUser): Promise<MessageResponse> {
     if (!(await this.sshkeysService.removeSshKey(user.id, uuidSshKey))) {
@@ -45,6 +47,7 @@ export class SshKeysController {
 
   // GET /sshkeys/my
   // This action gets all the ssh keys of the user
+  @ApiOkResponse({ type: ApiStandardResponse })
   @Get('my')
   async getSshKeys(@GetUser() user: RequestUser): Promise<CompliantContentResponse<SanitizedSshKey[]>> {
     return await this.sshkeysService.getSshKeysOfUser(user.id);
@@ -52,6 +55,7 @@ export class SshKeysController {
 
   // GET /sshkeys/
   // This action gets all ssh keys
+  @ApiOkResponse({ type: ApiStandardResponse })
   @AdminOnly()
   @Get()
   async getAllSshKeys(): Promise<CompliantContentResponse<SanitizedSshKey[]>> {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -2,7 +2,7 @@ import { SanitizedUser } from './types/sanitized-user.type';
 import { BadRequestException, Controller, Delete, Get, Param } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { AdminOnly } from 'src/decorators/adminonly.decorator';
-import { ApiBearerAuth, ApiCookieAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiCookieAuth, ApiOkResponse, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { GetUser } from 'src/decorators/user.decorator';
 import { RequestUser } from 'src/auth/types/jwt-user-data.type';
 import { ApiStandardResponse } from 'src/interfaces/standard-response.inteface';
@@ -19,6 +19,7 @@ export class UsersController {
   // GET /users
   // This action returns all users
   @AdminOnly()
+  @ApiOkResponse({ type: ApiStandardResponse })
   @Get()
   async findAll(): Promise<CompliantContentResponse<SanitizedUser[]>> {
     return await this.usersService.findAll();
@@ -26,6 +27,7 @@ export class UsersController {
 
   // GET /users/my
   // This action returns a user's profile
+  @ApiOkResponse({ type: ApiStandardResponse })
   @Get('my')
   async getProfile(@GetUser() user: RequestUser): Promise<CompliantContentResponse<SanitizedUser>> {
     return await this.usersService.findOne({ id: user.id });
@@ -33,6 +35,7 @@ export class UsersController {
 
   // GET /users/:username
   // This action returns a #${username} user
+  @ApiOkResponse({ type: ApiStandardResponse })
   @AdminOnly()
   @Get(':username')
   async findOne(@Param('username') username: string): Promise<CompliantContentResponse<SanitizedUser>> {
@@ -42,6 +45,7 @@ export class UsersController {
   // DELETE /users/:username
   // This action deletes a #${username} user
   @AdminOnly()
+  @ApiOkResponse({ type: ApiStandardResponse })
   @Delete(':username')
   async delete(@Param('username') username: string): Promise<MessageResponse> {
     try {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,6 @@
 // Minimum eight characters, at least one uppercase letter,
 // one lowercase letter, one number and one special character
-export const PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;
+export const PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]+$/;
 
 // starts with a letter, ends with a letter or a figure, contains alphanumerical and hyphens/underscores
 export const USERNAME_REGEX = /^[A-Za-z][A-Za-z0-9_-]+[A-Za-z0-9]$/;


### PR DESCRIPTION
This PR adds Swagger response decorators (`@ApiResponse`, `@ApiOkResponse`, etc.) directly to routes, since adding them just at the beginning of a Controller is not enough (it only sets a default response type, not the main one, which is still deduced by CLI plugin as an empty object).

Since website autogenerates request functions based on the openapi spec given by NestJS, it is useful to have a clearly defined response type. If somebody finds out a way to do it without manually adding a decorator to each route, that would be great :)